### PR TITLE
Allow specifying options as environment variables

### DIFF
--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -212,5 +212,10 @@ def reset():
     _board.enter_raw_repl()
     _board.exit_raw_repl()
 
+
+def run():
+    cli(auto_envvar_prefix='AMPY')
+
+
 if __name__ == '__main__':
-    cli()
+    run()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=['click', 'pyserial'],
     entry_points={
         'console_scripts': [
-            'ampy=ampy.cli:cli',
+            'ampy=ampy.cli:run',
         ],
     },
 )


### PR DESCRIPTION
So that we can do:

```bash
$ export AMPY_PORT=/dev/ttyUSB0
$ ampy ls
```