### PR TITLE
teach mkdir about --exists-okay

### DIFF
--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -101,8 +101,9 @@ def get(remote_file, local_file):
         local_file.write(contents)
 
 @cli.command()
+@click.option('--exists-okay', is_flag=True)
 @click.argument('directory')
-def mkdir(directory):
+def mkdir(directory, exists_okay):
     """
     Create a directory on the board.
 
@@ -119,7 +120,8 @@ def mkdir(directory):
     """
     # Run the mkdir command.
     board_files = files.Files(_board)
-    board_files.mkdir(directory)
+    board_files.mkdir(directory,
+                      exists_okay=exists_okay)
 
 @cli.command()
 @click.argument('directory', default='/')

--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -228,8 +228,9 @@ def rm(remote_file):
     board_files.rm(remote_file)
 
 @cli.command()
+@click.option('--missing-okay', is_flag=True)
 @click.argument('remote_folder')
-def rmdir(remote_folder):
+def rmdir(remote_folder, missing_okay):
     """Forcefully remove a folder and all its children from the board.
 
     Remove the specified folder from the board's filesystem.  Must specify one
@@ -243,7 +244,7 @@ def rmdir(remote_folder):
     """
     # Delete the provided file/directory on the board.
     board_files = files.Files(_board)
-    board_files.rmdir(remote_folder)
+    board_files.rmdir(remote_folder, missing_okay=missing_okay)
 
 @cli.command()
 @click.argument('local_file')

--- a/ampy/files.py
+++ b/ampy/files.py
@@ -105,7 +105,7 @@ class Files(object):
         # Parse the result list and return it.
         return ast.literal_eval(out.decode('utf-8'))
 
-    def mkdir(self, directory):
+    def mkdir(self, directory, exists_okay=False):
         """Create the specified directory.  Note this cannot create a recursive
         hierarchy of directories, instead each one should be created separately.
         """
@@ -123,7 +123,8 @@ class Files(object):
         except PyboardError as ex:
             # Check if this is an OSError #17, i.e. directory already exists.
             if ex.args[2].decode('utf-8').find('OSError: [Errno 17] EEXIST') != -1:
-                raise DirectoryExistsError('Directory already exists: {0}'.format(directory))
+                if not exists_okay:
+                    raise DirectoryExistsError('Directory already exists: {0}'.format(directory))
             else:
                 raise ex
         self._pyboard.exit_raw_repl()

--- a/ampy/files.py
+++ b/ampy/files.py
@@ -172,7 +172,7 @@ class Files(object):
                 raise ex
         self._pyboard.exit_raw_repl()
 
-    def rmdir(self, directory):
+    def rmdir(self, directory, missing_okay=False):
         """Forcefully remove the specified directory and all its children."""
         # Build a script to walk an entire directory structure and delete every
         # file and subfolder.  This is tricky because MicroPython has no os.walk
@@ -209,7 +209,8 @@ class Files(object):
             # Check if this is an OSError #2, i.e. directory doesn't exist
             # and rethrow it as something more descriptive.
             if message.find('OSError: [Errno 2] ENOENT') != -1:
-                raise RuntimeError('No such directory: {0}'.format(directory))
+                if not missing_okay:
+                    raise RuntimeError('No such directory: {0}'.format(directory))
             else:
                 raise ex
         self._pyboard.exit_raw_repl()


### PR DESCRIPTION
adds the --exists-okay flag to the mkdir command, which allows you to
avoid errors if you are calling mkdir to ensure that a directory exists.