### PR TITLE
Added optional -d/--delay param for nRF52

### DIFF
--- a/ampy/__init__.py
+++ b/ampy/__init__.py
@@ -1,2 +1,2 @@
 # Version of the application.
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -54,8 +54,11 @@ def windows_full_port_name(portname):
 @click.option('--baud', '-b', envvar='AMPY_BAUD', default=115200, type=click.INT,
               help='Baud rate for the serial connection (default 115200).  Can optionally specify with AMPY_BAUD environment variable.',
               metavar='BAUD')
+@click.option('--delay', '-d', envvar='AMPY_DELAY', default=0, type=click.FLOAT,
+              help='Delay in seconds before entering RAW MODE (default 0). Can optionally specify with AMPY_DELAY environment variable.',
+              metavar='DELAY')
 @click.version_option()
-def cli(port, baud):
+def cli(port, baud, delay):
     """ampy - Adafruit MicroPython Tool
 
     Ampy is a tool to control MicroPython boards over a serial connection.  Using
@@ -67,7 +70,7 @@ def cli(port, baud):
     # windows_full_port_name function).
     if platform.system() == 'Windows':
         port = windows_full_port_name(port)
-    _board = pyboard.Pyboard(port, baudrate=baud)
+    _board = pyboard.Pyboard(port, baudrate=baud, rawdelay=delay)
 
 @cli.command()
 @click.argument('remote_file')

--- a/ampy/pyboard.py
+++ b/ampy/pyboard.py
@@ -40,6 +40,8 @@ Or:
 import sys
 import time
 
+_rawdelay = None
+
 try:
     stdout = sys.stdout.buffer
 except AttributeError:
@@ -117,7 +119,9 @@ class TelnetToSerial:
             return n_waiting
 
 class Pyboard:
-    def __init__(self, device, baudrate=115200, user='micro', password='python', wait=0):
+    def __init__(self, device, baudrate=115200, user='micro', password='python', wait=0, rawdelay=0):
+        global _rawdelay
+        _rawdelay = rawdelay
         if device and device[0].isdigit() and device[-1].isdigit() and device.count('.') == 3:
             # device looks like an IP address
             self.serial = TelnetToSerial(device, user, password, read_timeout=10)
@@ -169,6 +173,10 @@ class Pyboard:
         return data
 
     def enter_raw_repl(self):
+        # Brief delay before sending RAW MODE char if requests
+        if _rawdelay > 0:
+            time.sleep(_rawdelay)
+
         self.serial.write(b'\r\x03\x03') # ctrl-C twice: interrupt any running program
 
         # flush input (without relying on serial.flushInput())


### PR DESCRIPTION
This PR adds an optional `-d` / `--delay` parameter which inserts a float-based delay in seconds before the command sequence to enter RAW mode is sent. This is required due to the nature of the bootloader on the nRF52, and may be require on some variants of the ESP* family as well.

Tested successfully against the nRF52 with the following command sequence:

```
$ ampy -p /dev/tty.SLAB_USBtoUART -d 1.5 run boards/feather52/test.py
```
