### PR TITLE
Introduce an additional small delay in _enter_raw_repl

### DIFF
--- a/ampy/pyboard.py
+++ b/ampy/pyboard.py
@@ -202,7 +202,9 @@ class Pyboard:
         #   Add a small delay and send Ctrl-C twice after soft reboot to ensure
         #   any main program loop in main.py is interrupted.
         time.sleep(0.5)
-        self.serial.write(b'\x03\x03')
+        self.serial.write(b'\x03')
+        time.sleep(0.1)           # (slight delay before second interrupt
+        self.serial.write(b'\x03')
         # End modification above.
         data = self.read_until(1, b'raw REPL; CTRL-B to exit\r\n')
         if not data.endswith(b'raw REPL; CTRL-B to exit\r\n'):


### PR DESCRIPTION
I was having trouble when my 'main code' looked like this:
```
 with adafruit_dotstar.DotStar(APA102_SCK, APA102_MOSI, 1) as pixels:
    for i in range(10):
        pixels[0] = 0x000070
        time.sleep(.2)
```
[and, maybe relevantly, running CP3.0 from master branch on Trinket M0]

Putting the small delay here fixes it.

I hope that this also fixes adafruit/circuitpython#636