### PR TITLE
fixed bugs with 'ls'. Added recursive to 'ls', along with some beauty…

### DIFF
--- a/ampy/files.py
+++ b/ampy/files.py
@@ -106,7 +106,7 @@ class Files(object):
 
         if recursive:
             command += """\
-                def listdir(dir):
+                def listdir(directory):
                     result = set()
 
                     def _listdir(dir_or_file):
@@ -132,15 +132,15 @@ class Files(object):
                             else:
                                 result.add(dir_or_file)                     
 
-                    _listdir(dir)
+                    _listdir(directory)
                     return sorted(result)\n"""
         else:
             command += """\
-                def listdir(dir):
-                    if dir == '/':                
-                        return sorted([dir + f for f in os.listdir(dir)])
+                def listdir(directory):
+                    if directory == '/':                
+                        return sorted([directory + f for f in os.listdir(directory)])
                     else:
-                        return sorted([dir + '/' + f for f in os.listdir(dir)])\n"""
+                        return sorted([directory + '/' + f for f in os.listdir(directory)])\n"""
 
         # Execute os.listdir() command on the board.
         if long_format:

--- a/ampy/files.py
+++ b/ampy/files.py
@@ -26,8 +26,8 @@ from ampy.pyboard import PyboardError
 
 
 BUFFER_SIZE = 32  # Amount of data to read or write to the serial port at a time.
-                  # This is kept small because small chips and USB to serial
-                  # bridges usually have very small buffers.
+# This is kept small because small chips and USB to serial
+# bridges usually have very small buffers.
 
 
 class DirectoryExistsError(Exception):
@@ -64,21 +64,23 @@ class Files(object):
                     if result == b'':
                         break
                     len = sys.stdout.write(result)
-        """.format(filename, BUFFER_SIZE)
+        """.format(
+            filename, BUFFER_SIZE
+        )
         self._pyboard.enter_raw_repl()
         try:
             out = self._pyboard.exec_(textwrap.dedent(command))
         except PyboardError as ex:
             # Check if this is an OSError #2, i.e. file doesn't exist and
             # rethrow it as something more descriptive.
-            if ex.args[2].decode('utf-8').find('OSError: [Errno 2] ENOENT') != -1:
-                raise RuntimeError('No such file: {0}'.format(filename))
+            if ex.args[2].decode("utf-8").find("OSError: [Errno 2] ENOENT") != -1:
+                raise RuntimeError("No such file: {0}".format(filename))
             else:
                 raise ex
         self._pyboard.exit_raw_repl()
         return out
 
-    def ls(self, directory='/', long_format=True):
+    def ls(self, directory="/", long_format=True, recursive=False):
         """List the contents of the specified directory (or root if none is
         specified).  Returns a list of strings with the names of files in the
         specified directory.  If long_format is True then a list of 2-tuples
@@ -86,45 +88,90 @@ class Files(object):
         it appears the size of directories is not supported by MicroPython and
         will always return 0 (i.e. no recursive size computation).
         """
-        # Make sure directory ends in a slash.
-        if not directory.endswith('/'):
-            directory += '/'
+
+        # Disabling for now, see https://github.com/adafruit/ampy/issues/55.
+        # # Make sure directory ends in a slash.
+        # if not directory.endswith("/"):
+        #     directory += "/"
+
+        # Make sure directory starts with slash, for consistency.
+        if not directory.startswith("/"):
+            directory = "/" + directory
+
+        command = """\
+                try:        
+                    import os
+                except ImportError:
+                    import uos as os\n"""
+
+        if recursive:
+            command += """\
+                def listdir(dir):
+                    result = set()
+
+                    def _listdir(dir_or_file):
+                        try:
+                            # if its a directory, then it should provide some children.
+                            children = os.listdir(dir_or_file)
+                        except OSError:                        
+                            # probably a file. run stat() to confirm.
+                            os.stat(dir_or_file)
+                            result.add(dir_or_file) 
+                        else:
+                            # probably a directory, add to result if empty.
+                            if children:
+                                # queue the children to be dealt with in next iteration.
+                                for child in children:
+                                    # create the full path.
+                                    if dir_or_file == '/':
+                                        next = dir_or_file + child
+                                    else:
+                                        next = dir_or_file + '/' + child
+                                    
+                                    _listdir(next)
+                            else:
+                                result.add(dir_or_file)                     
+
+                    _listdir(dir)
+                    return sorted(result)\n"""
+        else:
+            command += """\
+                def listdir(dir):
+                    if dir == '/':                
+                        return sorted([dir + f for f in os.listdir(dir)])
+                    else:
+                        return sorted([dir + '/' + f for f in os.listdir(dir)])\n"""
+
         # Execute os.listdir() command on the board.
         if long_format:
-            command = """
-                try:
-                    import os
-                except ImportError:
-                    import uos as os
-                d = '{0}'
+            command += """
                 r = []
-                for f in os.listdir(d):
-                    fp = d + f
-                    _, _, _, _, _, _, size, _, _, _ = os.stat(fp)
+                for f in listdir('{0}'):
+                    size = os.stat(f)[6]                    
                     r.append('{{0}} - {{1}} bytes'.format(f, size))
                 print(r)
-            """.format(directory)
+            """.format(
+                directory
+            )
         else:
-            command = """
-                try:
-                    import os
-                except ImportError:
-                    import uos as os
-                print(os.listdir('{0}'))
-            """.format(directory)
+            command += """
+                print(listdir('{0}'))
+            """.format(
+                directory
+            )
         self._pyboard.enter_raw_repl()
         try:
             out = self._pyboard.exec_(textwrap.dedent(command))
         except PyboardError as ex:
             # Check if this is an OSError #2, i.e. directory doesn't exist and
             # rethrow it as something more descriptive.
-            if ex.args[2].decode('utf-8').find('OSError: [Errno 2] ENOENT') != -1:
-                raise RuntimeError('No such directory: {0}'.format(directory))
+            if ex.args[2].decode("utf-8").find("OSError: [Errno 2] ENOENT") != -1:
+                raise RuntimeError("No such directory: {0}".format(directory))
             else:
                 raise ex
         self._pyboard.exit_raw_repl()
         # Parse the result list and return it.
-        return ast.literal_eval(out.decode('utf-8'))
+        return ast.literal_eval(out.decode("utf-8"))
 
     def mkdir(self, directory, exists_okay=False):
         """Create the specified directory.  Note this cannot create a recursive
@@ -137,15 +184,19 @@ class Files(object):
             except ImportError:
                 import uos as os
             os.mkdir('{0}')
-        """.format(directory)
+        """.format(
+            directory
+        )
         self._pyboard.enter_raw_repl()
         try:
             out = self._pyboard.exec_(textwrap.dedent(command))
         except PyboardError as ex:
             # Check if this is an OSError #17, i.e. directory already exists.
-            if ex.args[2].decode('utf-8').find('OSError: [Errno 17] EEXIST') != -1:
+            if ex.args[2].decode("utf-8").find("OSError: [Errno 17] EEXIST") != -1:
                 if not exists_okay:
-                    raise DirectoryExistsError('Directory already exists: {0}'.format(directory))
+                    raise DirectoryExistsError(
+                        "Directory already exists: {0}".format(directory)
+                    )
             else:
                 raise ex
         self._pyboard.exit_raw_repl()
@@ -159,13 +210,13 @@ class Files(object):
         size = len(data)
         # Loop through and write a buffer size chunk of data at a time.
         for i in range(0, size, BUFFER_SIZE):
-            chunk_size = min(BUFFER_SIZE, size-i)
-            chunk = repr(data[i:i+chunk_size])
+            chunk_size = min(BUFFER_SIZE, size - i)
+            chunk = repr(data[i : i + chunk_size])
             # Make sure to send explicit byte strings (handles python 2 compatibility).
-            if not chunk.startswith('b'):
-                chunk = 'b' + chunk
+            if not chunk.startswith("b"):
+                chunk = "b" + chunk
             self._pyboard.exec_("f.write({0})".format(chunk))
-        self._pyboard.exec_('f.close()')
+        self._pyboard.exec_("f.close()")
         self._pyboard.exit_raw_repl()
 
     def rm(self, filename):
@@ -176,19 +227,21 @@ class Files(object):
             except ImportError:
                 import uos as os
             os.remove('{0}')
-        """.format(filename)
+        """.format(
+            filename
+        )
         self._pyboard.enter_raw_repl()
         try:
             out = self._pyboard.exec_(textwrap.dedent(command))
         except PyboardError as ex:
-            message = ex.args[2].decode('utf-8')
+            message = ex.args[2].decode("utf-8")
             # Check if this is an OSError #2, i.e. file/directory doesn't exist
             # and rethrow it as something more descriptive.
-            if message.find('OSError: [Errno 2] ENOENT') != -1:
-                raise RuntimeError('No such file/directory: {0}'.format(filename))
+            if message.find("OSError: [Errno 2] ENOENT") != -1:
+                raise RuntimeError("No such file/directory: {0}".format(filename))
             # Check for OSError #13, the directory isn't empty.
-            if message.find('OSError: [Errno 13] EACCES') != -1:
-                raise RuntimeError('Directory is not empty: {0}'.format(filename))
+            if message.find("OSError: [Errno 13] EACCES") != -1:
+                raise RuntimeError("Directory is not empty: {0}".format(filename))
             else:
                 raise ex
         self._pyboard.exit_raw_repl()
@@ -221,17 +274,19 @@ class Files(object):
                 os.chdir('..')
                 os.rmdir(directory)
             rmdir('{0}')
-        """.format(directory)
+        """.format(
+            directory
+        )
         self._pyboard.enter_raw_repl()
         try:
             out = self._pyboard.exec_(textwrap.dedent(command))
         except PyboardError as ex:
-            message = ex.args[2].decode('utf-8')
+            message = ex.args[2].decode("utf-8")
             # Check if this is an OSError #2, i.e. directory doesn't exist
             # and rethrow it as something more descriptive.
-            if message.find('OSError: [Errno 2] ENOENT') != -1:
+            if message.find("OSError: [Errno 2] ENOENT") != -1:
                 if not missing_okay:
-                    raise RuntimeError('No such directory: {0}'.format(directory))
+                    raise RuntimeError("No such directory: {0}".format(directory))
             else:
                 raise ex
         self._pyboard.exit_raw_repl()
@@ -249,7 +304,7 @@ class Files(object):
         else:
             # Read the file and run it using lower level pyboard functions that
             # won't wait for it to finish or return output.
-            with open(filename, 'rb') as infile:
+            with open(filename, "rb") as infile:
                 self._pyboard.exec_raw_no_follow(infile.read())
         self._pyboard.exit_raw_repl()
         return out

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -22,6 +22,7 @@
 import tempfile
 import sys
 import unittest
+
 # Try importing python 3 mock library, then fall back to python 2 (external module).
 try:
     import unittest.mock as mock
@@ -33,11 +34,10 @@ from ampy.pyboard import PyboardError
 
 
 class TestFiles(unittest.TestCase):
-
     def raisesRegex(self, *args, **kwargs):
         # Wrapper to work with the different names for assertRaisesRegex vs.
         # assertRaisesRegexp in Python 3 vs. 2 (ugh).
-        if sys.version_info >= (3,2):
+        if sys.version_info >= (3, 2):
             return self.assertRaisesRegex(*args, **kwargs)
         else:
             return self.assertRaisesRegexp(*args, **kwargs)
@@ -47,7 +47,7 @@ class TestFiles(unittest.TestCase):
         pyboard.exec_ = mock.Mock(return_value=b"['boot.py', 'main.py', 'foo.txt']")
         board_files = files.Files(pyboard)
         result = board_files.ls()
-        self.assertListEqual(result, ['boot.py', 'main.py', 'foo.txt'])
+        self.assertListEqual(result, ["boot.py", "main.py", "foo.txt"])
 
     def test_ls_no_files(self):
         pyboard = mock.Mock()
@@ -58,63 +58,93 @@ class TestFiles(unittest.TestCase):
 
     def test_ls_bad_directory(self):
         pyboard = mock.Mock()
-        pyboard.exec_ = mock.Mock(side_effect=PyboardError('exception', b'', b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 2] ENOENT\r\n'))
-        with self.raisesRegex(RuntimeError, 'No such directory: /foo'):
+        pyboard.exec_ = mock.Mock(
+            side_effect=PyboardError(
+                "exception",
+                b"",
+                b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 2] ENOENT\r\n',
+            )
+        )
+        with self.raisesRegex(RuntimeError, "No such directory: /foo"):
             board_files = files.Files(pyboard)
-            result = board_files.ls('/foo')
+            result = board_files.ls("/foo")
 
     def test_get_with_data(self):
         pyboard = mock.Mock()
         pyboard.exec_ = mock.Mock(return_value=b"hello world")
         board_files = files.Files(pyboard)
-        result = board_files.get('foo.txt')
+        result = board_files.get("foo.txt")
         self.assertEqual(result, b"hello world")
 
     def test_get_bad_file(self):
         pyboard = mock.Mock()
-        pyboard.exec_ = mock.Mock(side_effect=PyboardError('exception', b'', b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 2] ENOENT\r\n'))
-        with self.raisesRegex(RuntimeError, 'No such file: foo.txt'):
+        pyboard.exec_ = mock.Mock(
+            side_effect=PyboardError(
+                "exception",
+                b"",
+                b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 2] ENOENT\r\n',
+            )
+        )
+        with self.raisesRegex(RuntimeError, "No such file: foo.txt"):
             board_files = files.Files(pyboard)
-            result = board_files.get('foo.txt')
+            result = board_files.get("foo.txt")
 
     def test_put(self):
         pyboard = mock.Mock()
         pyboard.exec_ = mock.Mock(return_value=b"")
         board_files = files.Files(pyboard)
-        board_files.put('foo.txt', 'hello world')
+        board_files.put("foo.txt", "hello world")
 
     def test_rm(self):
         pyboard = mock.Mock()
         pyboard.exec_ = mock.Mock(return_value=b"")
         board_files = files.Files(pyboard)
-        board_files.rm('foo.txt')
+        board_files.rm("foo.txt")
 
     def test_rm_file_doesnt_exist(self):
         pyboard = mock.Mock()
-        pyboard.exec_ = mock.Mock(side_effect=PyboardError('exception', b'', b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 2] ENOENT\r\n'))
-        with self.raisesRegex(RuntimeError, 'No such file/directory: foo.txt'):
+        pyboard.exec_ = mock.Mock(
+            side_effect=PyboardError(
+                "exception",
+                b"",
+                b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 2] ENOENT\r\n',
+            )
+        )
+        with self.raisesRegex(RuntimeError, "No such file/directory: foo.txt"):
             board_files = files.Files(pyboard)
-            result = board_files.rm('foo.txt')
+            result = board_files.rm("foo.txt")
 
     def test_rm_directory_not_empty(self):
         pyboard = mock.Mock()
-        pyboard.exec_ = mock.Mock(side_effect=PyboardError('exception', b'', b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 13] EACCES\r\n'))
-        with self.raisesRegex(RuntimeError, 'Directory is not empty: foo'):
+        pyboard.exec_ = mock.Mock(
+            side_effect=PyboardError(
+                "exception",
+                b"",
+                b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 13] EACCES\r\n',
+            )
+        )
+        with self.raisesRegex(RuntimeError, "Directory is not empty: foo"):
             board_files = files.Files(pyboard)
-            result = board_files.rm('foo')
+            result = board_files.rm("foo")
 
     def test_rmdir(self):
         pyboard = mock.Mock()
         pyboard.exec_ = mock.Mock(return_value=b"")
         board_files = files.Files(pyboard)
-        board_files.rmdir('foo')
+        board_files.rmdir("foo")
 
     def test_rmdir_folder_doesnt_exist(self):
         pyboard = mock.Mock()
-        pyboard.exec_ = mock.Mock(side_effect=PyboardError('exception', b'', b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 2] ENOENT\r\n'))
-        with self.raisesRegex(RuntimeError, 'No such directory: foo'):
+        pyboard.exec_ = mock.Mock(
+            side_effect=PyboardError(
+                "exception",
+                b"",
+                b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 2] ENOENT\r\n',
+            )
+        )
+        with self.raisesRegex(RuntimeError, "No such directory: foo"):
             board_files = files.Files(pyboard)
-            result = board_files.rmdir('foo')
+            result = board_files.rmdir("foo")
 
     def test_run_with_output(self):
         pyboard = mock.Mock()
@@ -141,11 +171,23 @@ class TestFiles(unittest.TestCase):
         pyboard = mock.Mock()
         pyboard.exec_ = mock.Mock(return_value=b"")
         board_files = files.Files(pyboard)
-        board_files.mkdir('/foo')
+        board_files.mkdir("/foo")
 
     def test_mkdir_directory_already_exists(self):
         pyboard = mock.Mock()
-        pyboard.exec_ = mock.Mock(side_effect=PyboardError('exception', b'', b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 17] EEXIST\r\n'))
-        with self.raisesRegex(files.DirectoryExistsError, 'Directory already exists: /foo'):
+        pyboard.exec_ = mock.Mock(
+            side_effect=PyboardError(
+                "exception",
+                b"",
+                b'Traceback (most recent call last):\r\n  File "<stdin>", line 3, in <module>\r\nOSError: [Errno 17] EEXIST\r\n',
+            )
+        )
+        with self.raisesRegex(
+            files.DirectoryExistsError, "Directory already exists: /foo"
+        ):
             board_files = files.Files(pyboard)
-            board_files.mkdir('/foo')
+            board_files.mkdir("/foo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- fix #55.
- Add a recursive mode to `ls` command.
- Always display the file/dir names as the full path with a leading slash for least confusion.
- Code format with black (my editor was rigged to do it, sorry).

*Tested on Wemos D1 Mini*

----

Here are some examples of what I did -

(`...` == ` -p /dev/ttyUSB0 -b 115200`)

```
⋊ ~/ampy> ampy ... ls -r -l
/boot.py - 0 bytes
/glove/common/__init__.mpy - 82 bytes
/glove/common/config.mpy - 302 bytes
/glove/common/unetwork.mpy - 5956 bytes
/glove/micropython/__init__.mpy - 82 bytes
/glove/micropython/glove.mpy - 915 bytes
/glove/micropython/imu.mpy - 8321 bytes
/glove/micropython/mpu9250.mpy - 4472 bytes
/glove/micropython/vector3d.mpy - 4081 bytes
/main.py - 30 bytes
```

```
⋊ ~/ampy> ampy ...  ls -r /glove
/glove/common/__init__.mpy
/glove/common/config.mpy
/glove/common/unetwork.mpy
/glove/micropython/__init__.mpy
/glove/micropython/glove.mpy
/glove/micropython/imu.mpy
/glove/micropython/mpu9250.mpy
/glove/micropython/vector3d.mpy
```

*The leading slash is automatically added,  if not present.*

```
⋊ ~/ampy> ampy ...  ls glove
/glove/common
/glove/micropython
```
```
⋊ ~/ampy> ampy ...  ls -l glove/common 
/glove/common/__init__.mpy - 82 bytes
/glove/common/config.mpy - 302 bytes
/glove/common/unetwork.mpy - 5956 bytes
```

---

I tried to stick to the code style you guys have, but this is the best I could do. 

Please accept this request, navigating the directory structure is a real pain right now. Hopefully, this pull request makes it easier for everyone.

Thanks!

----

P.S. Try out this pull request in your nearest personal computer today!

```
$ git clone https://github.com/devxpy/ampy.git
$ cd ampy
$ pip install -e .
```

---

[🐍🏕️](http://www.pycampers.com/)