### PR TITLE
import binascii if ubinascii not found

### DIFF
--- a/ampy/files.py
+++ b/ampy/files.py
@@ -59,7 +59,10 @@ class Files(object):
         # expects string data.
         command = """
             import sys
-            import ubinascii
+            try:
+                import ubinascii
+            except:
+                import binascii as ubinascii
             with open('{0}', 'rb') as infile:
                 while True:
                     result = infile.read({1})

--- a/files.txt
+++ b/files.txt
@@ -1,3 +1,0 @@
-/usr/local/bin/ampy
-/usr/local/bin/dotenv
-/usr/local/lib/python3.8/dist-packages/adafruit_ampy-1.1.0-py3.8.egg

--- a/files.txt
+++ b/files.txt
@@ -1,0 +1,3 @@
+/usr/local/bin/ampy
+/usr/local/bin/dotenv
+/usr/local/lib/python3.8/dist-packages/adafruit_ampy-1.1.0-py3.8.egg


### PR DESCRIPTION
addresses #110 
Circuitpython now uses binascii so the "get"  command fails trying to import ubinascii.
This PR adds a try/except to import binascii as ubinascii if  ubinascii is not present.
