### PR TITLE
use raw string to escape regex sequence

### DIFF
--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -50,7 +50,7 @@ def windows_full_port_name(portname):
     # 9 are just referred to by COM1, COM2, etc. (wacky!)  See this post for
     # more info and where this code came from:
     # http://eli.thegreenplace.net/2009/07/31/listing-all-serial-ports-on-windows-with-python/
-    m = re.match("^COM(\d+)$", portname)
+    m = re.match(r"^COM(\d+)$", portname)
     if m and int(m.group(1)) < 10:
         return portname
     else:


### PR DESCRIPTION
This addresses the SyntaxWarning for 'invalid escape sequence'

For example in a Python REPL or otherwise:

```python
import re

>>> match1 = re.match(r"^COM(\d+)$", "COM124")
>>> match1.group()
'COM124'
>>> match2 = re.match("^COM(\d+)$", "COM123")
<stdin>:1: SyntaxWarning: invalid escape sequence '\d'
>>> match2.group()
'COM123'
```

It appears that at least of Python v3.12.6 it has not resulted in an error. But perhaps worth fixing!